### PR TITLE
Use config methods instead of hard coding

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -1,3 +1,5 @@
+require 'yaml'
+
 module GuidingLight
   class << self
     attr_accessor :configuration
@@ -12,11 +14,18 @@ module GuidingLight
     attr_accessor :api_key, :api_url, :site_id, :solr_url
 
     def initialize
-      @api_key  = "DUMMY_API_KEY"
-      @api_url  = 'http://lgapi-us.libapps.com/1.1/guides/'
-      @site_id  = "42"
-      @solr_url = "http://localhost:8983/solr/blacklight-core"
+      begin
+        # load Gem config file if it exists
+        config = YAML.load_file(File.expand_path "config/libguides.yml")
+      rescue
+        config = {}
+      end
+      @api_key  = config.fetch 'api_key',  "DUMMY_API_KEY"
+      @api_url  = config.fetch 'api_url',  'http://lgapi-us.libapps.com/1.1/guides/'
+      @site_id  = config.fetch 'site_id',  "42"
+      @solr_url = config.fetch 'solr_url', "http://localhost:8983/solr/blacklight-core"
     end
+
 
   end
 end

--- a/lib/harvest_libguides.rb
+++ b/lib/harvest_libguides.rb
@@ -99,7 +99,7 @@ module HarvestLibguides
   end
 
   def self.harvest_all
-    config = YAML.load_file(File.expand_path "config/libguides.yml")
+    config = GuidingLight.configuration
     log = Logger.new("log/harvest_libguides.log")
     #
     # Harvest guides


### PR DESCRIPTION
Use the configuration method to allow the config to be set by apps using this.

Check if a config file is defined in the gem before setting defaults, and use that config. 

